### PR TITLE
Change behaviour significantly: make work for all cases

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -38,7 +38,7 @@ function autovenv --on-variable PWD -d "Automatic activation of Python virtual e
             # to split "/home". So the lack of a slash is what we do to tell us that "it's time to stop"
             break
         end
-        for _venv_dir in (find "$_tree" -maxdepth 1 -type d)
+        for _venv_dir in (find "$_tree" -maxdepth 1 -type d 2> /dev/null)
             if test -e "$_venv_dir/bin/activate.fish"
                 set _source "$_venv_dir/bin/activate.fish"
                 if test "$autovenv_announce" = "yes"

--- a/init.fish
+++ b/init.fish
@@ -31,7 +31,7 @@ function autovenv --on-variable PWD -d "Automatic activation of Python virtual e
     set -l _tree "$PWD/."
     set -l _done false
     while true
-        set _tree (string split -r -m 1 -n '/' "$_tree" | select 1)
+        set _tree (string split -r -m 1 -n '/' "$_tree")[1]
         if ! string match -q -- "/*" $_tree 
             # This is a hack to stop when we have ascended all the way up to the top of the tree.
             # The string split command above eventually returns something like "home" when it tries


### PR DESCRIPTION
-Start at current directory
-Look inside all sub-directories to see if there is a bin/activate.fish script
-If not found, look in the parent directory, and continue up the file path until one is found, or give up

Covers cases like:
-Virtual environment is in a .venv or venv folder (any folder name is supportd) in the current working directory
-Virtual environment is in a parent folder of the current working directory
-Virtual environment is in the current working directory